### PR TITLE
Fix css

### DIFF
--- a/src/teachbooks_questions/_static/teachbooks_questions.css
+++ b/src/teachbooks_questions/_static/teachbooks_questions.css
@@ -271,7 +271,12 @@ div.short-answer.blocks section.question-options div.sd-card-body.input math-fie
     color: #e89217;
   }
 
-div.multiple-choice div.sd-card .sd-card-body, div.multiple-choice .sd-card .sd-card-footer, div.multiple-choice .sd-card .sd-card-header,
-div.short-answer div.sd-card .sd-card-body, div.short-answer .sd-card .sd-card-footer, div.short-answer .sd-card .sd-card-header {
+div.multiple-choice .sd-card .sd-card-header,
+div.short-answer .sd-card .sd-card-header,
+div.multiple-choice div.sd-card .sd-card-body:not(.selected, .incorrect, .correct),
+div.short-answer div.sd-card .sd-card-body:not(.selected, .incorrect, .correct),
+div.multiple-choice .sd-card .sd-card-footer:not(.correct, .incorrect),
+div.short-answer .sd-card .sd-card-footer:not(.correct, .incorrect)
+ {
     background-color: transparent !important;
 }


### PR DESCRIPTION
This pull request makes a small style update to the question card components. The change ensures that the background color of certain card sections remains transparent unless they are marked as selected, correct, or incorrect.

* Updated CSS rules to set the background color of `.sd-card-header`, `.sd-card-body`, and `.sd-card-footer` to transparent for `.multiple-choice` and `.short-answer` cards, except when they have the `.selected`, `.correct`, or `.incorrect` classes.