### PR TITLE
Horizontal scroll

### DIFF
--- a/src/teachbooks_questions/_static/teachbooks_questions.css
+++ b/src/teachbooks_questions/_static/teachbooks_questions.css
@@ -190,7 +190,7 @@ div.short-answer.blocks section.question-options div.sd-card-body.input textarea
     min-height: 6rem;         /* initial size; adjust to taste */
     resize: vertical;         /* allow vertical resize only */
     overflow-y: auto;         /* vertical scrollbar if needed */
-    overflow-x: hidden;       /* no horizontal scrollbar */
+    overflow-x: auto;         /* horizontal scrollbar if needed */
     border: none;             /* optional: match card’s border instead */
     padding: .6rem .8rem;     /* optional */
     font: inherit;
@@ -216,12 +216,16 @@ div.short-answer.blocks section.question-options div.sd-card-footer.incorrect se
 }
 div.short-answer.blocks section.question-options div.sd-card-body.input section.question-option-answer {
     display: none;
+    overflow-x: auto;         /* enable horizontal scrolling when shown */
 }
 /* math stuff */
+div.short-answer.blocks section.question-options div.sd-card-body.input {
+    overflow-x: auto;         /* enable horizontal scrolling */
+}
 div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input {
     display: inline-block;           /* avoid inline quirks */
     box-sizing: border-box;   /* include padding/border in width/height */
-    width: 100%;
+    min-width: 100%;          /* at least full width, but can grow */
     height: 100%;             /* match container if container has a height */
     min-height: 6rem;         /* initial size; adjust to taste */
     border: none;             /* optional: match card’s border instead */

--- a/src/teachbooks_questions/_static/teachbooks_questions.css
+++ b/src/teachbooks_questions/_static/teachbooks_questions.css
@@ -233,23 +233,6 @@ div.short-answer.blocks section.question-options div.sd-card-body.input math-fie
     font: inherit;
     background-color: var(--question-white);
 }
-div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input::part(content) {
-    overflow-x: auto;         /* show horizontal scrollbar only when needed */
-    overflow-y: hidden;
-    white-space: nowrap;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-gutter: stable;
-}
-div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input::part(content)::-webkit-scrollbar {
-    height: 12px;
-}
-div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input::part(content)::-webkit-scrollbar-thumb {
-    background: rgba(120, 120, 120, 0.75);
-    border-radius: 8px;
-}
-div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input::part(content)::-webkit-scrollbar-track {
-    background: rgba(0, 0, 0, 0.08);
-}
 /* math-field icon colors (shadow DOM) */
 div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input::part(virtual-keyboard-toggle),
 div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input::part(menu-toggle) {

--- a/src/teachbooks_questions/_static/teachbooks_questions.css
+++ b/src/teachbooks_questions/_static/teachbooks_questions.css
@@ -220,7 +220,7 @@ div.short-answer.blocks section.question-options div.sd-card-body.input section.
 }
 /* math stuff */
 div.short-answer.blocks section.question-options div.sd-card-body.input {
-    overflow-x: auto;         /* enable horizontal scrolling */
+    overflow-x: scroll;       /* always show horizontal scrollbar */
     min-height: 6rem;         /* match math-field minimum */
 }
 div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input {
@@ -235,10 +235,21 @@ div.short-answer.blocks section.question-options div.sd-card-body.input math-fie
     background-color: var(--question-white);
 }
 div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input::part(content) {
-    overflow-x: auto;         /* MathLive internal content area */
+    overflow-x: scroll;       /* always show horizontal scrollbar */
     overflow-y: hidden;
     white-space: nowrap;
     -webkit-overflow-scrolling: touch;
+    scrollbar-gutter: stable;
+}
+div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input::part(content)::-webkit-scrollbar {
+    height: 12px;
+}
+div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input::part(content)::-webkit-scrollbar-thumb {
+    background: rgba(120, 120, 120, 0.75);
+    border-radius: 8px;
+}
+div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input::part(content)::-webkit-scrollbar-track {
+    background: rgba(0, 0, 0, 0.08);
 }
 /* math-field icon colors (shadow DOM) */
 div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input::part(virtual-keyboard-toggle),

--- a/src/teachbooks_questions/_static/teachbooks_questions.css
+++ b/src/teachbooks_questions/_static/teachbooks_questions.css
@@ -190,7 +190,7 @@ div.short-answer.blocks section.question-options div.sd-card-body.input textarea
     min-height: 6rem;         /* initial size; adjust to taste */
     resize: vertical;         /* allow vertical resize only */
     overflow-y: auto;         /* vertical scrollbar if needed */
-    overflow-x: auto;         /* horizontal scrollbar if needed */
+    overflow-x: hidden;       /* text answers stay multiline */
     border: none;             /* optional: match card’s border instead */
     padding: .6rem .8rem;     /* optional */
     font: inherit;
@@ -216,11 +216,10 @@ div.short-answer.blocks section.question-options div.sd-card-footer.incorrect se
 }
 div.short-answer.blocks section.question-options div.sd-card-body.input section.question-option-answer {
     display: none;
-    overflow-x: auto;         /* enable horizontal scrolling when shown */
 }
 /* math stuff */
-div.short-answer.blocks section.question-options div.sd-card-body.input {
-    overflow-x: scroll;       /* always show horizontal scrollbar */
+div.short-answer.blocks section.question-options div.sd-card-body.input:has(math-field.question-option-input) {
+    overflow-x: hidden;       /* keep outer card fixed; only math input scrolls */
     min-height: 6rem;         /* match math-field minimum */
 }
 div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input {
@@ -235,7 +234,7 @@ div.short-answer.blocks section.question-options div.sd-card-body.input math-fie
     background-color: var(--question-white);
 }
 div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input::part(content) {
-    overflow-x: scroll;       /* always show horizontal scrollbar */
+    overflow-x: auto;         /* show horizontal scrollbar only when needed */
     overflow-y: hidden;
     white-space: nowrap;
     -webkit-overflow-scrolling: touch;

--- a/src/teachbooks_questions/_static/teachbooks_questions.css
+++ b/src/teachbooks_questions/_static/teachbooks_questions.css
@@ -221,17 +221,24 @@ div.short-answer.blocks section.question-options div.sd-card-body.input section.
 /* math stuff */
 div.short-answer.blocks section.question-options div.sd-card-body.input {
     overflow-x: auto;         /* enable horizontal scrolling */
+    min-height: 6rem;         /* match math-field minimum */
 }
 div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input {
-    display: inline-block;           /* avoid inline quirks */
+    display: block;                  /* change from inline-block */
     box-sizing: border-box;   /* include padding/border in width/height */
-    min-width: 100%;          /* at least full width, but can grow */
+    width: 100%;              /* host takes card width */
     height: 100%;             /* match container if container has a height */
     min-height: 6rem;         /* initial size; adjust to taste */
-    border: none;             /* optional: match card’s border instead */
+    border: none;             /* optional: match card's border instead */
     padding: .6rem .8rem;     /* optional */
     font: inherit;
     background-color: var(--question-white);
+}
+div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input::part(content) {
+    overflow-x: auto;         /* MathLive internal content area */
+    overflow-y: hidden;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
 }
 /* math-field icon colors (shadow DOM) */
 div.short-answer.blocks section.question-options div.sd-card-body.input math-field.question-option-input::part(virtual-keyboard-toggle),

--- a/src/teachbooks_questions/_static/teachbooks_sab.js
+++ b/src/teachbooks_questions/_static/teachbooks_sab.js
@@ -285,7 +285,10 @@ function tunedSimilarity(student, correct) {
             display: inline-flex !important;
             flex-direction: row !important;
             align-items: center !important;
-            gap: 0.25rem;
+            justify-content: flex-start !important;
+            width: auto !important;
+            max-width: max-content;
+            gap: 0.15rem;
             white-space: nowrap;
           }
 
@@ -294,6 +297,9 @@ function tunedSimilarity(student, correct) {
             display: inline-flex !important;
             align-items: center;
             justify-content: center;
+            margin: 0 !important;
+            padding-left: 0.15rem;
+            padding-right: 0.15rem;
           }
 
           /* Keep scrolling possible on touch even when unfocused */

--- a/src/teachbooks_questions/_static/teachbooks_sab.js
+++ b/src/teachbooks_questions/_static/teachbooks_sab.js
@@ -247,30 +247,80 @@ function tunedSimilarity(student, correct) {
         return false;
       }
 
+      // Add internal styles once: MathLive renders in shadow DOM, so host CSS is not enough.
+      let styleTag = shadow.querySelector('style[data-tb-visible-scrollbar]');
+      if (!styleTag) {
+        styleTag = document.createElement('style');
+        styleTag.setAttribute('data-tb-visible-scrollbar', '1');
+        styleTag.textContent = `
+          .ML__container,
+          [part="container"] {
+            overflow-x: scroll !important;
+            overflow-y: hidden !important;
+            -webkit-overflow-scrolling: touch;
+            scrollbar-gutter: stable;
+          }
+
+          .ML__content,
+          [part="content"] {
+            overflow: visible !important;
+            white-space: nowrap !important;
+            width: max-content !important;
+            min-width: 100% !important;
+          }
+
+          /* Keep scrolling possible on touch even when unfocused */
+          :host(:not(:focus)) .ML__container,
+          :host(:not(:focus-within)) .ML__container {
+            pointer-events: auto !important;
+          }
+
+          /* Visible scrollbar styling */
+          .ML__container::-webkit-scrollbar,
+          [part="container"]::-webkit-scrollbar {
+            height: 12px;
+          }
+          .ML__container::-webkit-scrollbar-thumb,
+          [part="container"]::-webkit-scrollbar-thumb {
+            background: rgba(120, 120, 120, 0.75);
+            border-radius: 8px;
+          }
+          .ML__container::-webkit-scrollbar-track,
+          [part="container"]::-webkit-scrollbar-track {
+            background: rgba(0, 0, 0, 0.08);
+          }
+        `;
+        shadow.appendChild(styleTag);
+      }
+
       const container = shadow.querySelector('.ML__container, [part="container"]');
       const content = shadow.querySelector('.ML__content, [part="content"]');
 
       if (container) {
-        container.style.overflowX = 'auto';
+        container.style.overflowX = 'scroll';
         container.style.overflowY = 'hidden';
         container.style.webkitOverflowScrolling = 'touch';
         container.style.scrollbarGutter = 'stable';
+        container.style.scrollbarWidth = 'auto';
       }
 
       if (content) {
-        content.style.overflowX = 'auto';
-        content.style.overflowY = 'hidden';
+        content.style.overflowX = 'visible';
+        content.style.overflowY = 'visible';
         content.style.whiteSpace = 'nowrap';
         content.style.minWidth = '100%';
         content.style.width = 'max-content';
-        content.style.webkitOverflowScrolling = 'touch';
       }
 
       return Boolean(content);
     };
 
     if (!apply()) {
-      requestAnimationFrame(apply);
+      requestAnimationFrame(() => {
+        if (!apply()) {
+          setTimeout(apply, 50);
+        }
+      });
     }
   }
 

--- a/src/teachbooks_questions/_static/teachbooks_sab.js
+++ b/src/teachbooks_questions/_static/teachbooks_sab.js
@@ -278,18 +278,30 @@ function tunedSimilarity(student, correct) {
           .ML__toggles,
           .ML__virtual-keyboard-toggle,
           .ML__menu-toggle {
-            flex: 0 0 auto;
+            flex: 0 0 auto !important;
           }
 
           .ML__toggles {
-            display: inline-flex !important;
+            display: flex !important;
             flex-direction: row !important;
             align-items: center !important;
             justify-content: flex-start !important;
-            width: auto !important;
-            max-width: max-content;
-            gap: 0.15rem;
+            width: fit-content !important;
+            max-width: fit-content !important;
+            min-width: 0 !important;
+            gap: 0.1rem !important;
+            column-gap: 0.1rem !important;
+            row-gap: 0 !important;
             white-space: nowrap;
+            grid-template-columns: none !important;
+            margin: 0 !important;
+            padding: 0 !important;
+          }
+
+          .ML__toggles > * {
+            flex: 0 0 auto !important;
+            margin: 0 !important;
+            min-width: 0 !important;
           }
 
           .ML__virtual-keyboard-toggle,
@@ -298,8 +310,13 @@ function tunedSimilarity(student, correct) {
             align-items: center;
             justify-content: center;
             margin: 0 !important;
-            padding-left: 0.15rem;
-            padding-right: 0.15rem;
+            margin-inline: 0 !important;
+            margin-inline-start: 0 !important;
+            margin-inline-end: 0 !important;
+            padding-left: 0.1rem;
+            padding-right: 0.1rem;
+            min-width: 0 !important;
+            width: auto !important;
           }
 
           /* Keep scrolling possible on touch even when unfocused */

--- a/src/teachbooks_questions/_static/teachbooks_sab.js
+++ b/src/teachbooks_questions/_static/teachbooks_sab.js
@@ -236,6 +236,50 @@ function tunedSimilarity(student, correct) {
 }
 
 (function () {
+  function configureMathFieldHorizontalScroll(mathField) {
+    if (!mathField) {
+      return;
+    }
+
+    const apply = () => {
+      const shadow = mathField.shadowRoot;
+      if (!shadow) {
+        return false;
+      }
+
+      const container = shadow.querySelector('.ML__container, [part="container"]');
+      const content = shadow.querySelector('.ML__content, [part="content"]');
+
+      if (container) {
+        container.style.overflowX = 'auto';
+        container.style.overflowY = 'hidden';
+        container.style.webkitOverflowScrolling = 'touch';
+        container.style.scrollbarGutter = 'stable';
+      }
+
+      if (content) {
+        content.style.overflowX = 'auto';
+        content.style.overflowY = 'hidden';
+        content.style.whiteSpace = 'nowrap';
+        content.style.minWidth = '100%';
+        content.style.width = 'max-content';
+        content.style.webkitOverflowScrolling = 'touch';
+      }
+
+      return Boolean(content);
+    };
+
+    if (!apply()) {
+      requestAnimationFrame(apply);
+    }
+  }
+
+  function configureAllMathFields() {
+    document
+      .querySelectorAll('math-field.question-option-input')
+      .forEach((mathField) => configureMathFieldHorizontalScroll(mathField));
+  }
+
   function getQuestionDiv(element) {
     return element.closest('div.short-answer.blocks');
   }
@@ -475,6 +519,13 @@ function tunedSimilarity(student, correct) {
             radius = parts[1].trim();
             mathField.value = '\\text\{any number \}x\\text\{ such that \} |x - ' + centre + '| \\leq ' + radius + '\\cdot |' + centre + '|';
           }
+
+          configureMathFieldHorizontalScroll(mathField);
+          requestAnimationFrame(() => {
+            if (typeof mathField.executeCommand === 'function') {
+              mathField.executeCommand('scrollToStart');
+            }
+          });
         }
       }
     });
@@ -528,4 +579,10 @@ function tunedSimilarity(student, correct) {
       handleFocus(event.target);
     }
   }, true);
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', configureAllMathFields, { once: true });
+  } else {
+    configureAllMathFields();
+  }
 })();

--- a/src/teachbooks_questions/_static/teachbooks_sab.js
+++ b/src/teachbooks_questions/_static/teachbooks_sab.js
@@ -255,19 +255,28 @@ function tunedSimilarity(student, correct) {
         styleTag.textContent = `
           .ML__container,
           [part="container"] {
+            display: flex !important;
+            align-items: center;
             overflow-x: hidden !important;
             overflow-y: hidden !important;
           }
 
           .ML__content,
           [part="content"] {
+            flex: 1 1 auto;
             overflow-x: auto !important;
             overflow-y: hidden !important;
             white-space: nowrap !important;
-            width: max-content !important;
-            min-width: 100% !important;
+            width: auto !important;
+            min-width: 0 !important;
             -webkit-overflow-scrolling: touch;
             scrollbar-gutter: stable;
+          }
+
+          .ML__toggles,
+          .ML__virtual-keyboard-toggle,
+          .ML__menu-toggle {
+            flex: 0 0 auto;
           }
 
           /* Keep scrolling possible on touch even when unfocused */
@@ -306,8 +315,9 @@ function tunedSimilarity(student, correct) {
         content.style.overflowX = 'auto';
         content.style.overflowY = 'hidden';
         content.style.whiteSpace = 'nowrap';
-        content.style.minWidth = '100%';
-        content.style.width = 'max-content';
+        content.style.minWidth = '0';
+        content.style.width = 'auto';
+        content.style.flex = '1 1 auto';
         content.style.webkitOverflowScrolling = 'touch';
         content.style.scrollbarGutter = 'stable';
         content.style.scrollbarWidth = 'auto';

--- a/src/teachbooks_questions/_static/teachbooks_sab.js
+++ b/src/teachbooks_questions/_static/teachbooks_sab.js
@@ -475,7 +475,7 @@ function tunedSimilarity(student, correct) {
     }
   }
 
-  function clearShowAnswerMode(questionDiv, clearValues) {
+  function clearShowAnswerMode(questionDiv, clearValues, clearAllInputs) {
     if (!questionDiv) {
       return;
     }
@@ -485,17 +485,21 @@ function tunedSimilarity(student, correct) {
       const mathField = optionCard.querySelector('math-field.question-option-input');
 
       if (textArea && textArea.classList.contains('show-answer')) {
-        if (clearValues) {
+        if (clearValues || clearAllInputs) {
           textArea.value = '';
         }
         textArea.classList.remove('show-answer');
+      } else if (textArea && clearAllInputs) {
+        textArea.value = '';
       }
 
       if (mathField && mathField.classList.contains('show-answer')) {
-        if (clearValues) {
+        if (clearValues || clearAllInputs) {
           mathField.value = '';
         }
         mathField.classList.remove('show-answer');
+      } else if (mathField && clearAllInputs) {
+        mathField.value = '';
       }
 
       setReadOnlyState(textArea, mathField, false);
@@ -510,7 +514,7 @@ function tunedSimilarity(student, correct) {
 
     const questionOptionsSection = getQuestionOptionsSection(questionDiv);
     if (questionOptionsSection) {
-      clearShowAnswerMode(questionDiv, true);
+      clearShowAnswerMode(questionDiv, true, true);
       questionOptionsSection.querySelectorAll('div.sd-card-footer').forEach(function (footer) {
         footer.classList.remove('correct', 'incorrect');
       });
@@ -524,7 +528,7 @@ function tunedSimilarity(student, correct) {
     }
 
     // Clear show-answer mode in this question before checking submitted answers
-    clearShowAnswerMode(questionDiv, true);
+    clearShowAnswerMode(questionDiv, true, false);
 
     const questionOptionsSection = getQuestionOptionsSection(questionDiv);
     if (!questionOptionsSection) {
@@ -638,7 +642,7 @@ function tunedSimilarity(student, correct) {
       return;
     }
     // Remove all shown answers when resuming input mode
-    clearShowAnswerMode(questionDiv, true);
+    clearShowAnswerMode(questionDiv, true, false);
     // Remove all feedback
     questionDiv.querySelectorAll('div.sd-card-footer').forEach(function (footer) {
       footer.classList.remove('correct', 'incorrect');

--- a/src/teachbooks_questions/_static/teachbooks_sab.js
+++ b/src/teachbooks_questions/_static/teachbooks_sab.js
@@ -236,6 +236,8 @@ function tunedSimilarity(student, correct) {
 }
 
 (function () {
+  const MATH_SCROLL_STYLE_ID = 'data-tb-visible-scrollbar';
+
   function configureMathFieldHorizontalScroll(mathField) {
     if (!mathField) {
       return;
@@ -248,10 +250,10 @@ function tunedSimilarity(student, correct) {
       }
 
       // Add internal styles once: MathLive renders in shadow DOM, so host CSS is not enough.
-      let styleTag = shadow.querySelector('style[data-tb-visible-scrollbar]');
+      let styleTag = shadow.querySelector(`style[${MATH_SCROLL_STYLE_ID}]`);
       if (!styleTag) {
         styleTag = document.createElement('style');
-        styleTag.setAttribute('data-tb-visible-scrollbar', '1');
+        styleTag.setAttribute(MATH_SCROLL_STYLE_ID, '1');
         styleTag.textContent = `
           .ML__container,
           [part="container"] {
@@ -318,33 +320,7 @@ function tunedSimilarity(student, correct) {
         shadow.appendChild(styleTag);
       }
 
-      const container = shadow.querySelector('.ML__container, [part="container"]');
       const content = shadow.querySelector('.ML__content, [part="content"]');
-      const toggles = shadow.querySelector('.ML__toggles');
-
-      if (container) {
-        container.style.overflowX = 'hidden';
-        container.style.overflowY = 'hidden';
-      }
-
-      if (content) {
-        content.style.overflowX = 'auto';
-        content.style.overflowY = 'hidden';
-        content.style.whiteSpace = 'nowrap';
-        content.style.minWidth = '0';
-        content.style.width = 'auto';
-        content.style.flex = '1 1 auto';
-        content.style.webkitOverflowScrolling = 'touch';
-        content.style.scrollbarGutter = 'stable';
-        content.style.scrollbarWidth = 'auto';
-      }
-
-      if (toggles) {
-        toggles.style.display = 'inline-flex';
-        toggles.style.flexDirection = 'row';
-        toggles.style.alignItems = 'center';
-        toggles.style.gap = '0.25rem';
-      }
 
       return Boolean(content);
     };
@@ -493,6 +469,33 @@ function tunedSimilarity(student, correct) {
     }
   }
 
+  function clearShowAnswerMode(questionDiv, clearValues) {
+    if (!questionDiv) {
+      return;
+    }
+
+    questionDiv.querySelectorAll('div.sd-card.option').forEach(function (optionCard) {
+      const textArea = optionCard.querySelector('textarea.question-option-input');
+      const mathField = optionCard.querySelector('math-field.question-option-input');
+
+      if (textArea && textArea.classList.contains('show-answer')) {
+        if (clearValues) {
+          textArea.value = '';
+        }
+        textArea.classList.remove('show-answer');
+      }
+
+      if (mathField && mathField.classList.contains('show-answer')) {
+        if (clearValues) {
+          mathField.value = '';
+        }
+        mathField.classList.remove('show-answer');
+      }
+
+      setReadOnlyState(textArea, mathField, false);
+    });
+  }
+
   function handleResetClick(resetButton) {
     const questionDiv = getQuestionDiv(resetButton);
     if (!questionDiv) {
@@ -501,23 +504,9 @@ function tunedSimilarity(student, correct) {
 
     const questionOptionsSection = getQuestionOptionsSection(questionDiv);
     if (questionOptionsSection) {
-      questionOptionsSection.querySelectorAll('div.sd-card.option').forEach(function (optionCard) {
-        const footer = optionCard.querySelector('div.sd-card-footer');
-        const textArea = optionCard.querySelector('textarea.question-option-input');
-        const mathField = optionCard.querySelector('math-field.question-option-input');
-
-        if (footer) {
-          footer.classList.remove('correct', 'incorrect');
-        }
-        if (textArea) {
-          textArea.value = '';
-          textArea.classList.remove('show-answer');
-        }
-        if (mathField) {
-          mathField.value = '';
-          mathField.classList.remove('show-answer');
-        }
-        setReadOnlyState(textArea, mathField, false);
+      clearShowAnswerMode(questionDiv, true);
+      questionOptionsSection.querySelectorAll('div.sd-card-footer').forEach(function (footer) {
+        footer.classList.remove('correct', 'incorrect');
       });
     }
   }
@@ -529,17 +518,7 @@ function tunedSimilarity(student, correct) {
     }
 
     // Clear show-answer mode in this question before checking submitted answers
-    questionDiv.querySelectorAll('textarea.question-option-input.show-answer').forEach(function (ta) {
-      ta.value = '';
-      ta.classList.remove('show-answer');
-      ta.readOnly = false;
-    });
-    questionDiv.querySelectorAll('math-field.question-option-input.show-answer').forEach(function (mf) {
-      mf.value = '';
-      mf.classList.remove('show-answer');
-      mf.readOnly = false;
-      mf.removeAttribute('read-only');
-    });
+    clearShowAnswerMode(questionDiv, true);
 
     const questionOptionsSection = getQuestionOptionsSection(questionDiv);
     if (!questionOptionsSection) {
@@ -652,15 +631,8 @@ function tunedSimilarity(student, correct) {
     if (!questionDiv) {
       return;
     }
-    // Remove all answers
-    questionDiv.querySelectorAll('textarea.question-option-input.show-answer').forEach(function (ta) {
-      ta.value = '';
-      ta.classList.remove('show-answer');
-    });
-    questionDiv.querySelectorAll('math-field.question-option-input.show-answer').forEach(function (mf) {
-      mf.value = '';
-      mf.classList.remove('show-answer');
-    });
+    // Remove all shown answers when resuming input mode
+    clearShowAnswerMode(questionDiv, true);
     // Remove all feedback
     questionDiv.querySelectorAll('div.sd-card-footer').forEach(function (footer) {
       footer.classList.remove('correct', 'incorrect');

--- a/src/teachbooks_questions/_static/teachbooks_sab.js
+++ b/src/teachbooks_questions/_static/teachbooks_sab.js
@@ -279,6 +279,21 @@ function tunedSimilarity(student, correct) {
             flex: 0 0 auto;
           }
 
+          .ML__toggles {
+            display: inline-flex !important;
+            flex-direction: row !important;
+            align-items: center !important;
+            gap: 0.25rem;
+            white-space: nowrap;
+          }
+
+          .ML__virtual-keyboard-toggle,
+          .ML__menu-toggle {
+            display: inline-flex !important;
+            align-items: center;
+            justify-content: center;
+          }
+
           /* Keep scrolling possible on touch even when unfocused */
           :host(:not(:focus)) .ML__container,
           :host(:not(:focus-within)) .ML__container {
@@ -305,6 +320,7 @@ function tunedSimilarity(student, correct) {
 
       const container = shadow.querySelector('.ML__container, [part="container"]');
       const content = shadow.querySelector('.ML__content, [part="content"]');
+      const toggles = shadow.querySelector('.ML__toggles');
 
       if (container) {
         container.style.overflowX = 'hidden';
@@ -321,6 +337,13 @@ function tunedSimilarity(student, correct) {
         content.style.webkitOverflowScrolling = 'touch';
         content.style.scrollbarGutter = 'stable';
         content.style.scrollbarWidth = 'auto';
+      }
+
+      if (toggles) {
+        toggles.style.display = 'inline-flex';
+        toggles.style.flexDirection = 'row';
+        toggles.style.alignItems = 'center';
+        toggles.style.gap = '0.25rem';
       }
 
       return Boolean(content);
@@ -456,6 +479,20 @@ function tunedSimilarity(student, correct) {
     }
   }
 
+  function setReadOnlyState(textArea, mathField, readOnly) {
+    if (textArea) {
+      textArea.readOnly = readOnly;
+    }
+    if (mathField) {
+      mathField.readOnly = readOnly;
+      if (readOnly) {
+        mathField.setAttribute('read-only', '');
+      } else {
+        mathField.removeAttribute('read-only');
+      }
+    }
+  }
+
   function handleResetClick(resetButton) {
     const questionDiv = getQuestionDiv(resetButton);
     if (!questionDiv) {
@@ -480,6 +517,7 @@ function tunedSimilarity(student, correct) {
           mathField.value = '';
           mathField.classList.remove('show-answer');
         }
+        setReadOnlyState(textArea, mathField, false);
       });
     }
   }
@@ -490,14 +528,17 @@ function tunedSimilarity(student, correct) {
       return;
     }
 
-    // Clear any textareas with show-answer class
-    document.querySelectorAll('textarea.question-option-input.show-answer').forEach(function (ta) {
+    // Clear show-answer mode in this question before checking submitted answers
+    questionDiv.querySelectorAll('textarea.question-option-input.show-answer').forEach(function (ta) {
       ta.value = '';
       ta.classList.remove('show-answer');
+      ta.readOnly = false;
     });
-    document.querySelectorAll('math-field.question-option-input.show-answer').forEach(function (ta) {
-      ta.value = '';
-      ta.classList.remove('show-answer');
+    questionDiv.querySelectorAll('math-field.question-option-input.show-answer').forEach(function (mf) {
+      mf.value = '';
+      mf.classList.remove('show-answer');
+      mf.readOnly = false;
+      mf.removeAttribute('read-only');
     });
 
     const questionOptionsSection = getQuestionOptionsSection(questionDiv);
@@ -556,6 +597,7 @@ function tunedSimilarity(student, correct) {
       if (mathField) {
         mathField.classList.add('show-answer');
       }
+      setReadOnlyState(textArea, mathField, true);
 
       if (answerSection) {
         if (textArea) {
@@ -593,6 +635,18 @@ function tunedSimilarity(student, correct) {
   }
 
   function handleFocus(element) {
+    // In show-answer mode, focusing should not reset content;
+    // users should leave this mode via Try again (or Submit).
+    if (element.classList && element.classList.contains('show-answer')) {
+      return;
+    }
+    if (element.tagName === 'TEXTAREA' && element.readOnly) {
+      return;
+    }
+    if (element.tagName === 'MATH-FIELD' && (element.readOnly || element.hasAttribute('read-only'))) {
+      return;
+    }
+
     // get the parent question div
     const questionDiv = getQuestionDiv(element);
     if (!questionDiv) {

--- a/src/teachbooks_questions/_static/teachbooks_sab.js
+++ b/src/teachbooks_questions/_static/teachbooks_sab.js
@@ -295,6 +295,7 @@ function tunedSimilarity(student, correct) {
             white-space: nowrap;
             grid-template-columns: none !important;
             margin: 0 !important;
+            margin-left: 0.5rem !important;
             padding: 0 !important;
           }
 
@@ -303,7 +304,7 @@ function tunedSimilarity(student, correct) {
             flex-direction: row !important;
             grid-template-columns: none !important;
             row-gap: 0 !important;
-            column-gap: 0.1rem !important;
+            column-gap: 0.5rem !important;
             width: fit-content !important;
             max-width: fit-content !important;
           }

--- a/src/teachbooks_questions/_static/teachbooks_sab.js
+++ b/src/teachbooks_questions/_static/teachbooks_sab.js
@@ -255,18 +255,19 @@ function tunedSimilarity(student, correct) {
         styleTag.textContent = `
           .ML__container,
           [part="container"] {
-            overflow-x: scroll !important;
+            overflow-x: hidden !important;
             overflow-y: hidden !important;
-            -webkit-overflow-scrolling: touch;
-            scrollbar-gutter: stable;
           }
 
           .ML__content,
           [part="content"] {
-            overflow: visible !important;
+            overflow-x: auto !important;
+            overflow-y: hidden !important;
             white-space: nowrap !important;
             width: max-content !important;
             min-width: 100% !important;
+            -webkit-overflow-scrolling: touch;
+            scrollbar-gutter: stable;
           }
 
           /* Keep scrolling possible on touch even when unfocused */
@@ -275,18 +276,18 @@ function tunedSimilarity(student, correct) {
             pointer-events: auto !important;
           }
 
-          /* Visible scrollbar styling */
-          .ML__container::-webkit-scrollbar,
-          [part="container"]::-webkit-scrollbar {
+          /* Scrollbar styling for the input area */
+          .ML__content::-webkit-scrollbar,
+          [part="content"]::-webkit-scrollbar {
             height: 12px;
           }
-          .ML__container::-webkit-scrollbar-thumb,
-          [part="container"]::-webkit-scrollbar-thumb {
+          .ML__content::-webkit-scrollbar-thumb,
+          [part="content"]::-webkit-scrollbar-thumb {
             background: rgba(120, 120, 120, 0.75);
             border-radius: 8px;
           }
-          .ML__container::-webkit-scrollbar-track,
-          [part="container"]::-webkit-scrollbar-track {
+          .ML__content::-webkit-scrollbar-track,
+          [part="content"]::-webkit-scrollbar-track {
             background: rgba(0, 0, 0, 0.08);
           }
         `;
@@ -297,19 +298,19 @@ function tunedSimilarity(student, correct) {
       const content = shadow.querySelector('.ML__content, [part="content"]');
 
       if (container) {
-        container.style.overflowX = 'scroll';
+        container.style.overflowX = 'hidden';
         container.style.overflowY = 'hidden';
-        container.style.webkitOverflowScrolling = 'touch';
-        container.style.scrollbarGutter = 'stable';
-        container.style.scrollbarWidth = 'auto';
       }
 
       if (content) {
-        content.style.overflowX = 'visible';
-        content.style.overflowY = 'visible';
+        content.style.overflowX = 'auto';
+        content.style.overflowY = 'hidden';
         content.style.whiteSpace = 'nowrap';
         content.style.minWidth = '100%';
         content.style.width = 'max-content';
+        content.style.webkitOverflowScrolling = 'touch';
+        content.style.scrollbarGutter = 'stable';
+        content.style.scrollbarWidth = 'auto';
       }
 
       return Boolean(content);

--- a/src/teachbooks_questions/_static/teachbooks_sab.js
+++ b/src/teachbooks_questions/_static/teachbooks_sab.js
@@ -298,6 +298,16 @@ function tunedSimilarity(student, correct) {
             padding: 0 !important;
           }
 
+          .ML__toggles--vertical {
+            display: flex !important;
+            flex-direction: row !important;
+            grid-template-columns: none !important;
+            row-gap: 0 !important;
+            column-gap: 0.1rem !important;
+            width: fit-content !important;
+            max-width: fit-content !important;
+          }
+
           .ML__toggles > * {
             flex: 0 0 auto !important;
             margin: 0 !important;


### PR DESCRIPTION
Solve issue #3 

- Makes math input field horizontally scrollable with scroll bar
- Now if clicking the answer field in show-answer mode, you don't immediatly go to input mode --> this allows clicking it for scrolling

Tested here: https://oit.tudelft.nl/CTB3330/test-scroll/plasticity/lesson3/exercise3.html

<img width="457" height="389" alt="image" src="https://github.com/user-attachments/assets/33a7f5a0-3002-44a3-a530-03730c59f1b1" />
<img width="448" height="281" alt="image" src="https://github.com/user-attachments/assets/0a3d09ba-0b0a-450a-979c-70149e5584c9" />
<img width="469" height="425" alt="image" src="https://github.com/user-attachments/assets/30e6f0c6-e3db-4be7-80a5-9cb4e39ab7a1" />
