### PR TITLE
Fix wrong formatting for feedback with or

### DIFF
--- a/src/teachbooks_questions/_static/teachbooks_sab.js
+++ b/src/teachbooks_questions/_static/teachbooks_sab.js
@@ -549,7 +549,7 @@ function formatRangeEvalfDisplay(intervalExpression, evalfSetting) {
               const normalized = ans.trim().replace(/\\;/g, ';');
               return formatEvalfDisplay(normalized, evalfSetting);
             });
-            mathField.value = correctAnswers.join('\\quad\\text{or}\\quad');
+            mathField.value = correctAnswers.join('\\quad\\text{or}\\quad{}');
           } else if (mathField.classList.contains('type-MR') || mathField.classList.contains('type-MNR')) {
             // for M(N)R type, we want to show some extra text to indicate the correct answer is a range
             mathField.value = '\\text\{any number \}x\\text\{ such that \}' + formatRangeEvalfDisplay(answerSection.textContent.trim(), evalfSetting);


### PR DESCRIPTION
This:
```
::::{question} Opgave
:type: short-answer
:variant: blocks
:admonition:
:class: exercise
:nocaption:
:showanswer:

Neem als statisch onbepaalde kracht de verticale oplegreactie bij $\rm{B}$ (positief omhoog). Wat is de vormveranderingsvoorwaarde? Gebruik de variabele $w_{\rm{...}}$ voor een verplaatsing.
---
M[w_B = 0 ; w(B) = 0]
---

::::
```
Gave as feedback:
<img width="951" height="415" alt="image" src="https://github.com/user-attachments/assets/f57c849b-9f8c-4b07-8ee2-0e3345e4b5ca" />
